### PR TITLE
Use IA32_APIC_BASE MSR to get LAPIC address instead of the MADT

### DIFF
--- a/kernel-src/arch/x86-64/apic.c
+++ b/kernel-src/arch/x86-64/apic.c
@@ -5,6 +5,7 @@
 #include <kernel/interrupt.h>
 #include <arch/cpu.h>
 #include <arch/hpet.h>
+#include <arch/msr.h>
 #include <kernel/timer.h>
 #include <kernel/timekeeper.h>
 
@@ -262,12 +263,7 @@ void arch_apic_init() {
 
 	// map LAPIC to virtual memory
 
-	struct acpi_madt_lapic_address_override *lapic64 = getentry(ACPI_MADT_ENTRY_TYPE_LAPIC_ADDRESS_OVERRIDE, 0);
-
-	void *paddr = lapic64 ? (void *)lapic64->address : (void *)(uint64_t)madt->local_interrupt_controller_address;
-
-	if (lapic64)
-		printf("\e[94mUsing 64 bit override for the local APIC address\n\e[0m");
+    void *paddr = (void *) rdmsr(MSR_IA32APICBASE);
 
 	lapic_address = vmm_map(NULL, PAGE_SIZE, VMM_FLAGS_PHYSICAL, ARCH_MMU_FLAGS_READ | ARCH_MMU_FLAGS_WRITE | ARCH_MMU_FLAGS_NOEXEC, paddr);
 	__assert(lapic_address);

--- a/kernel-src/include/x86-64/arch/msr.h
+++ b/kernel-src/include/x86-64/arch/msr.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 
+#define MSR_IA32APICBASE 0x1B
 #define MSR_EFER 0xC0000080
 #define MSR_STAR 0xC0000081
 #define MSR_LSTAR 0xC0000082


### PR DESCRIPTION
Obtaining the LAPIC address should be done by reading the `IA32_APIC_BASE` MSR, instead of retrieving it from the MADT or from the LAPIC address override entry, when this entry is present.