### PR TITLE
Small fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,22 @@ IMG=$(JINX_DIR)/astral-bootable.img
 DISKNAME=$(JINX_DIR)/hdd.img
 LIMINEDIR=$(JINX_DIR)/host-pkgs/limine/usr/local/share/limine/
 KERNEL=$(JINX_DIR)/builds/astral/astral
-QEMUFLAGS=-M q35 -m 2g -smp cpus=4 -no-shutdown -no-reboot -debugcon file:/dev/stdout -serial stdio -netdev user,id=net0 -device virtio-net,netdev=net0 -object filter-dump,id=f1,netdev=net0,file=netdump.dat
+QEMUFLAGS=\
+	-M q35 \
+	-m 2g \
+	-smp cpus=4 \
+	-no-shutdown \
+	-no-reboot \
+	-debugcon file:/dev/stdout \
+	-serial stdio \
+	-netdev user,id=net0 -device virtio-net,netdev=net0 \
+	-object filter-dump,id=f1,netdev=net0,file=netdump.dat
 QEMUISOFLAGS=-cdrom $(ISO)
 QEMUDISKFLAGS=-drive file=$(DISKNAME),if=none,id=nvme -device nvme,serial=deadc0ff,drive=nvme -boot order=dc
 QEMUIMGFLAGS=-drive file=$(IMG),if=none,id=usb -device nec-usb-xhci,id=xhci -device usb-storage,bus=xhci.0,drive=usb,removable=on
 INITRD=$(JINX_DIR)/initrds/initrd
 DISTROTYPE=full
+INITRDTYPE=minimal
 
 MINIMALPACKAGES=mlibc bash coreutils init distro-files vim nano mount shadow sudo xbps net-base neofetch
 
@@ -44,15 +54,15 @@ $(JINX_DIR)/.astral_ok: jinx
 iso: $(ISO)
 img: $(IMG)
 
-$(ISO): limine.conf liminebg.bmp $(KERNEL) $(INITRD)-$(DISTROTYPE)
+$(ISO): limine.conf liminebg.bmp $(KERNEL) $(INITRD)-$(INITRDTYPE)
 	mkdir -p $(ISODIR)
-	ln -f $(INITRD)-$(DISTROTYPE) $(ISODIR)/initrd
+	ln -f $(INITRD)-$(INITRDTYPE) $(ISODIR)/initrd
 	cp $(KERNEL) liminebg.bmp limine.conf $(LIMINEDIR)/limine-bios.sys $(LIMINEDIR)/limine-bios-cd.bin $(LIMINEDIR)/limine-uefi-cd.bin $(ISODIR)
 	xorriso -as mkisofs -b limine-bios-cd.bin -no-emul-boot -boot-load-size 4 -boot-info-table --efi-boot limine-uefi-cd.bin -efi-boot-part --efi-boot-image --protective-msdos-label $(ISODIR) -o $(ISO)
 
-$(IMG): limine.conf liminebg.bmp $(KERNEL) $(INITRD)-$(DISTROTYPE)
+$(IMG): limine.conf liminebg.bmp $(KERNEL) $(INITRD)-$(INITRDTYPE)
 	mkdir -p $(IMGDIR)/EFI/BOOT
-	ln -f $(INITRD)-$(DISTROTYPE) $(IMGDIR)/initrd
+	ln -f $(INITRD)-$(INITRDTYPE) $(IMGDIR)/initrd
 	cp $(KERNEL) liminebg.bmp limine.conf $(LIMINEDIR)/limine-bios.sys $(IMGDIR)
 	cp $(LIMINEDIR)/BOOTIA32.EFI $(IMGDIR)/EFI/BOOT
 	cp $(LIMINEDIR)/BOOTX64.EFI $(IMGDIR)/EFI/BOOT
@@ -90,8 +100,8 @@ $(INITRD)-minimal: distro-minimal
 
 initrd:
 	cd $(JINX_DIR) && \
-	rm $(INITRD)-$(DISTROTYPE) && \
-	make $(INITRD)-$(DISTROTYPE)
+	rm $(INITRD)-$(INITRDTYPE) && \
+	make $(INITRD)-$(INITRDTYPE)
 
 # ------ disk targets ------
 

--- a/gen_compile_db.py
+++ b/gen_compile_db.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# Generates a compile_commands.json file for the kernel
+
+import os
+import pathlib
+import json
+
+path = pathlib.Path(__file__).resolve()
+kernel_source = path.parent / 'kernel-src'
+cflags = []
+
+with open(kernel_source / 'Makefile', 'r') as f:
+    lines = f.readlines()
+
+    def find_var(name):
+        line = next(x for x in lines if x.startswith(f'{name}='))
+        value = line.strip().split('=', 1)[1].strip()
+
+        # Handle comment
+        if '#' in value:
+            value = value.split('#', 1)[0].strip()
+
+        return value
+
+    cflags_var = find_var('CFLAGS').split()
+    uacpiopts_var = find_var('UACPIOPTS').split()
+    printfopts_var = find_var('PRINTFOPTS').split()
+    kernelconfig_var = find_var('KERNELCONFIG').split()
+    flantermopts_var = find_var('FLANTERMOPTS').split()
+
+    incdir = kernel_source / 'include'
+    archincdir = kernel_source / 'include' / 'x86-64'
+    flantermincdir = kernel_source / 'flanterm'
+    uacpiincdir = kernel_source / 'io' / 'acpi' / 'uacpi' / 'include'
+
+    for f in cflags_var:
+        if f == '"$(UACPIINCDIR)"':
+            cflags.append(str(uacpiincdir))
+        elif f == '"$(INCDIR)"':
+            cflags.append(str(incdir))
+        elif f == '"$(ARCHINCDIR)"':
+            cflags.append(str(archincdir))
+        elif f == '"$(FLANTERMINCDIR)"':
+            cflags.append(str(flantermincdir))
+        elif f == '$(UACPIOPTS)':
+            cflags.extend(uacpiopts_var)
+        elif f == '$(PRINTFOPTS)':
+            cflags.extend(printfopts_var)
+        elif f == '$(KERNELCONFIG)':
+            cflags.extend(kernelconfig_var)
+        elif f == '$(FLANTERMOPTS)':
+            cflags.extend(flantermopts_var)
+        else:
+            cflags.append(f)
+
+csources = [
+    os.path.join(root, f)
+    for root, _, files in os.walk(kernel_source)
+    for f in files
+    if f.endswith('.c') and '/uacpi/tests/' not in os.path.join(root, f)
+]
+
+compile_commands = []
+
+for src in csources:
+    command = {
+        'directory': str(kernel_source),
+        'arguments': ['gcc', *cflags, '-c', src],
+        'file': src
+    }
+    compile_commands.append(command)
+
+with open(kernel_source / 'compile_commands.json', 'w') as f:
+    json.dump(compile_commands, f, indent=2)

--- a/kernel-src/Makefile
+++ b/kernel-src/Makefile
@@ -13,7 +13,7 @@ FLANTERMINCDIR=$(shell pwd)/flanterm
 UACPIINCDIR=$(shell pwd)/io/acpi/uacpi/include
 UACPIOPTS=-DUACPI_OVERRIDE_LIBC -DUACPI_KERNEL_INITIALIZATION -DUACPI_NATIVE_ALLOC_ZEROED
 KERNELCONFIG=#-DX86_64_ENABLE_E9 -DENABLE_PROFILING #-DSYSCALL_LOGGING
-CFLAGS=-g -ffreestanding -mcmodel=kernel -O2 -mno-red-zone -mgeneral-regs-only -mno-mmx -mno-sse -mno-sse2 -nostdlib -Wall -MMD -I "${INCDIR}" -I "$(ARCHINCDIR)" -I "$(FLANTERMINCDIR)" -I "$(UACPIINCDIR)" $(UACPIOPTS) $(PRINTFOPTS) $(KERNELCONFIG) $(FLANTERMOPTS) -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -std=gnu17 -Wno-error=implicit-function-declaration
+CFLAGS=-g -ffreestanding -mcmodel=kernel -O2 -mno-red-zone -mgeneral-regs-only -mno-mmx -mno-sse -mno-sse2 -nostdlib -Wall -MMD -I "$(INCDIR)" -I "$(ARCHINCDIR)" -I "$(FLANTERMINCDIR)" -I "$(UACPIINCDIR)" $(UACPIOPTS) $(PRINTFOPTS) $(KERNELCONFIG) $(FLANTERMOPTS) -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -std=gnu17 -Wno-error=implicit-function-declaration
 ASFLAGS=-felf64
 DEPS=$(CSOURCES:.c=.d)
 


### PR DESCRIPTION
Build initrd with minimal distro by default, split up QEMUFLAGS into multiple lines for readability + ease of modifying, add gen_compile_db.py for generating compile_commands.json for LSP