### PR TITLE
thread: Fix process destruction on multi-threaded processes

### DIFF
--- a/kernel-src/sys/thread.c
+++ b/kernel-src/sys/thread.c
@@ -96,8 +96,9 @@ __attribute__((noreturn)) void sched_threadexit() {
 
 			proc_exit();
 			vmm_destroycontext(oldctx);
-			PROC_RELEASE(proc);
 		}
+
+		PROC_RELEASE(proc);
 	}
 
 	interrupt_set(false);


### PR DESCRIPTION
Each thread holds one reference to the process. They weren't being dropped correctly before.

Should work fine but didn't care to build a full Astral GCC on my WSL2 install.