### PR TITLE
jinx: fix building on non-x86_64 hosts

### DIFF
--- a/Jinxfile
+++ b/Jinxfile
@@ -3,7 +3,13 @@ JINX_DEBIAN_SNAPSHOT=20260430T144239Z
 JINX_BASE_PACKAGES="autopoint bison cmake docbook-xsl docbook-xml docbook-xsl-ns docbook5-xml doxygen file flex gettext groff m4 make meson ninja-build perl python3 texinfo w3m which xmlto xsltproc"
 JINX_REPO_URL="https://astral-os.org/repository/${JINX_ARCH}/"
 
-export CFLAGS="-O2 -march=x86-64 -pipe -mtune=generic"
+# Can't use -march=x86-64 and whatnot in global CFLAGS on non-x86_64 hosts, since it affects host-recipes too
+# FIXME: should separate target vs host CFLAGS at some point
+if [ "$(uname -m)" = "x86_64" ]; then
+	export CFLAGS="-O2 -march=x86-64 -pipe -mtune=generic"
+else
+	export CFLAGS="-O2 -pipe"
+fi
 export CXXFLAGS="${CFLAGS}"
 
 copy_install_hook () {

--- a/recipes/ncurses
+++ b/recipes/ncurses
@@ -14,7 +14,10 @@ build() {
 }
 
 package() {
-	make install DESTDIR="${dest_dir}"
+	# ncurses hardcodes a bare `install -s` (INSTALL_OPT_S), which would strip the
+	# x86_64 target binaries with the host's native strip and fail on non-x86_64
+	# hosts. Point install at the cross strip so the binaries are still stripped.
+	make install DESTDIR="${dest_dir}" INSTALL_PROG='$(INSTALL) -s --strip-program=x86_64-astral-strip'
 
 	echo "INPUT(-lncursesw)" > ${dest_dir}${prefix}/lib/libncurses.so
 	echo "INPUT(-ltinfow)" > ${dest_dir}${prefix}/lib/libtinfo.so

--- a/recipes/vim
+++ b/recipes/vim
@@ -29,7 +29,9 @@ build() {
 }
 
 package() {
-	make install DESTDIR=${dest_dir}
+	# vim strips the installed binary with a bare `$(STRIP)`; use the cross strip
+	# so it works when building for x86_64 on a non-x86_64 host.
+	make install DESTDIR=${dest_dir} STRIP=x86_64-astral-strip
 	
 	mkdir -p ${dest_dir}/bin
 	pushd ${dest_dir}/bin


### PR DESCRIPTION
Allows building Astral on non-x86_64 hosts (e.g. aarch64).